### PR TITLE
不要なプラグイン定義を削除

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "cakephp/debug_kit":            "~2.2",
         "cakedc/migrations":            "~2.2",
         "components/jquery":            "~2.1",
-        "josegonzalez/cakephp-upload":  "~1.1",
         "phpunit/phpunit":              "~3.7.38",
         "twbs/bootstrap":               "~3.1"
     },


### PR DESCRIPTION
josegonzalez/cakephp-uploadは、Filesプラグインで定義されているため、不要なので削除します。