### PR TITLE
回答通知メールの設定画面で文面を変更できないようにしたかったのでpermissionOnlyを追加

### DIFF
--- a/View/Elements/edit_form.ctp
+++ b/View/Elements/edit_form.ctp
@@ -89,7 +89,7 @@ echo $this->NetCommonsHtml->css(array(
 								<?php endif; ?>
 
 								<?php echo $this->NetCommonsForm->input('MailSettingFixedPhrase.' . $index . '.mail_fixed_phrase_subject', array(
-									'type' => 'text',
+									'type' => ($editForm['permissionOnly']) ? 'hidden' :'text',
 									'label' => __d('mails', 'Subject'),
 									'required' => true,
 									'value' => $mailSettingFixedPhrase['mail_fixed_phrase_subject'],
@@ -97,7 +97,7 @@ echo $this->NetCommonsHtml->css(array(
 
 								<div class="form-group">
 									<?php echo $this->NetCommonsForm->input('MailSettingFixedPhrase.' . $index . '.mail_fixed_phrase_body', array(
-										'type' => 'textarea',
+										'type' => ($editForm['permissionOnly']) ? 'hidden' :'textarea',
 										'label' => __d('mails', 'Body'),
 										'required' => true,
 										'value' => $mailSettingFixedPhrase['mail_fixed_phrase_body'],
@@ -105,8 +105,10 @@ echo $this->NetCommonsHtml->css(array(
 									)); ?>
 									<?php
 									// popover説明
-									$mailHelp = $this->NetCommonsHtml->mailHelp($editForm['mailBodyPopoverMessage']);
-									echo $this->NetCommonsForm->help($mailHelp);
+									if ($editForm['permissionOnly'] === false) {
+										$mailHelp = $this->NetCommonsHtml->mailHelp($editForm['mailBodyPopoverMessage']);
+										echo $this->NetCommonsForm->help($mailHelp);
+									}
 									?>
 								</div>
 							</div>

--- a/View/Helper/MailFormHelper.php
+++ b/View/Helper/MailFormHelper.php
@@ -104,6 +104,7 @@ class MailFormHelper extends AppHelper {
 					'mailBodyPopoverMessage' => __d('mails', 'MailSetting.mail_fixed_phrase_body.popover'),
 					'permission' => 'mail_content_receivable',
 					'useNoticeAuthority' => 1,
+					'permissionOnly' => false,
 				),
 				array(
 					'mailTypeKey' => MailSettingFixedPhrase::ANSWER_TYPE,
@@ -111,6 +112,7 @@ class MailFormHelper extends AppHelper {
 					'mailBodyPopoverMessage' => __d('mails', 'MailSetting.mail_fixed_phrase_body.popover.answer'),
 					'permission' => 'mail_answer_receivable',
 					'useNoticeAuthority' => 1,
+					'permissionOnly' => false,
 				),
 			), $editForms);
 
@@ -123,6 +125,7 @@ class MailFormHelper extends AppHelper {
 					'mailBodyPopoverMessage' => __d('mails', 'MailSetting.mail_fixed_phrase_body.popover'),
 					'permission' => 'mail_content_receivable',
 					'useNoticeAuthority' => 1,
+					'permissionOnly' => false,
 				),
 			), $editForms);
 		}


### PR DESCRIPTION
権限設定だけを入力させたくてオプション追加してみました。