### PR TITLE
メール送信対象の権限抽出のロジックに誤り

### DIFF
--- a/Utility/NetCommonsMail.php
+++ b/Utility/NetCommonsMail.php
@@ -303,7 +303,9 @@ class NetCommonsMail extends CakeEmail {
 			$permissions = $WorkflowComponent->getBlockRolePermissions(array($sendRoomPermission),
 				$roomId, $blockKey);
 
-			$roleKeys = array_keys($permissions['BlockRolePermissions'][$sendRoomPermission]);
+			$permRoleKeys = Hash::extract(
+				$permissions['BlockRolePermissions'][$sendRoomPermission], '{s}[value=1]');
+			$roleKeys = Hash::extract($permRoleKeys, '{n}.role_key');
 			$conditions = array(
 				'Room.id' => $roomId,
 				'RolesRoom.role_key' => $roleKeys,


### PR DESCRIPTION
メール送信対象の権限（通知する権限）を取り出すロジックに誤りがあり、
現在DBに存在する全ての権限が常に通知対象になっていた。
block_role_permissionsに定義されている権限だけを取り出すように修正