### PR TITLE
メールフレーズを取得したらBehaivor内部にキャッシュしているが、言語、プラグイン、メールタイプ別になってなかったため、同じリクエスト…

### DIFF
--- a/Model/Behavior/MailQueueBehavior.php
+++ b/Model/Behavior/MailQueueBehavior.php
@@ -389,13 +389,13 @@ class MailQueueBehavior extends ModelBehavior {
  */
 	private function __getMailSettingPlugin(Model $model, $languageId,
 											$typeKey = MailSettingFixedPhrase::DEFAULT_TYPE) {
-		if (!$this->_mailSettingPlugin) {
-			$settingPluginKey = $this->__getSettingPluginKey($model);
+		$settingPluginKey = $this->__getSettingPluginKey($model);
+		if (!isset($this->_mailSettingPlugin[$languageId][$typeKey][$settingPluginKey])) {
 			/** @see MailSetting::getMailSettingPlugin() */
-			$this->_mailSettingPlugin = $model->MailSetting->getMailSettingPlugin($languageId, $typeKey,
-				$settingPluginKey);
+			$this->_mailSettingPlugin[$languageId][$typeKey][$settingPluginKey] =
+				$model->MailSetting->getMailSettingPlugin($languageId, $typeKey, $settingPluginKey);
 		}
-		return $this->_mailSettingPlugin;
+		return $this->_mailSettingPlugin[$languageId][$typeKey][$settingPluginKey];
 	}
 
 /**


### PR DESCRIPTION
メールフレーズを取得したらBehaivor内部にキャッシュしているが、言語、プラグイン、メールタイプ別になってなかったため、同じリクエスト中に別言語で送ろうとしたり、別のメールタイプのメールを送ろうとしても送ることができなかった。

言語、プラグイン、メールタイプ別に内部キャッシュするようにした。