### PR TITLE
NetCommonsMailでUserのメールフィールドがemail, moblie_mailに決め打ちになっていたのを修正

### DIFF
--- a/Test/Case/Utility/NetCommonsMail/GetReceivableEmailsFromUserTest.php
+++ b/Test/Case/Utility/NetCommonsMail/GetReceivableEmailsFromUserTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * GetReceivableEmailsFromUserTest.php
+ *
+ * @author   Ryuji AMANO <ryuji@ryus.co.jp>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ */
+
+App::uses('NetCommonsCakeTestCase', 'NetCommons.TestSuite');
+App::uses('NetCommonsMail', 'Mails.Utility');
+
+/**
+ * Class GetReceivableEmailsFromUserTest
+ */
+final class GetReceivableEmailsFromUserTest extends \NetCommonsCakeTestCase {
+
+/**
+ * @var string[] fixtures
+ */
+	public $fixtures = [
+		'plugin.mails.user_attribute_setting_for_get_receivable_emails_from_user_test'
+	];
+
+/**
+ * UserAttributeSettingでemailとされてるフィールドで送信が許可されているメールアドレスを返す
+ *
+ * @return void
+ * @throws ReflectionException
+ */
+	public function testGetEmailsWhereUserAttributeSettingIsEmailAndIsReceptionIsTrue() {
+		$user = [
+			'User' => [
+				'email' => 'email@example.com',
+				'is_email_reception' => true,
+				'moblie_mail' => 'mobile@example.com',
+				'is_moblie_mail_reception' => true,
+				'other_mail' => 'other@example.com',
+				'is_other_mail_reception' => true,
+			]
+		];
+
+		$receivableEmails = $this->__invokeGetReceivableEmailsFromUser($user);
+		$expected = [
+			'email@example.com',
+			'mobile@example.com',
+			'other@example.com'
+		];
+		$this->assertSame($expected, $receivableEmails);
+	}
+
+/**
+ * testメールアドレスが設定されていてもメールを受け取る設定になっていなければメールアドレスを取得できない
+ *
+ * @return void
+ * @throws ReflectionException
+ */
+	public function testNotGetEmailsWhereIsReceptionIsFalse() {
+		$user = [
+			'User' => [
+				'email' => 'email@example.com',
+				'is_email_reception' => false,
+				'other_mail' => 'other@example.com',
+				'is_other_mail_reception' => false,
+			]
+		];
+
+		$receivableEmails = $this->__invokeGetReceivableEmailsFromUser($user);
+
+		$this->assertSame([], $receivableEmails);
+	}
+
+/**
+ * NetCommonsMail::__getReceivableEmailsFromUserの実行
+ *
+ * @param array $user
+ * @return mixed
+ * @throws ReflectionException
+ */
+	private function __invokeGetReceivableEmailsFromUser(array $user) : array {
+		$netCommonsMail = new NetCommonsMail();
+		$sendMethod = new ReflectionMethod($netCommonsMail, '__getReceivableEmailsFromUser');
+		$sendMethod->setAccessible(true);
+		return $sendMethod->invoke($netCommonsMail, $user);
+	}
+}

--- a/Test/Case/Utility/NetCommonsMail/SendQueueMailTest.php
+++ b/Test/Case/Utility/NetCommonsMail/SendQueueMailTest.php
@@ -32,6 +32,7 @@ class MailsUtilityNetCommonsMailSendQueueMailTest extends NetCommonsCakeTestCase
 		'plugin.rooms.default_role_permission4test',
 		'plugin.rooms.room_role',
 		'plugin.rooms.room_role_permission4test',
+		'plugin.mails.user_attribute_setting_for_mail'
 	);
 
 /**

--- a/Test/Fixture/UserAttributeSettingForGetReceivableEmailsFromUserTestFixture.php
+++ b/Test/Fixture/UserAttributeSettingForGetReceivableEmailsFromUserTestFixture.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * UserAttributeSettingFixture
+ *
+ * @author Noriko Arai <arai@nii.ac.jp>
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+App::uses('UserAttributeSettingFixture', 'UserAttributes.Test/Fixture');
+
+/**
+ * UserAttributeSettingFixture
+ *
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @package NetCommons\UserAttributes\Test\Fixture
+ * @codeCoverageIgnore
+ */
+class UserAttributeSettingForGetReceivableEmailsFromUserTestFixture extends UserAttributeSettingFixture {
+
+/**
+ * Model name
+ *
+ * @var string
+ */
+	public $name = 'UserAttributeSetting';
+
+/**
+ * Full Table Name
+ *
+ * @var string
+ */
+	public $table = 'user_attribute_settings';
+
+/**
+ * Records
+ *
+ * @var array
+ */
+	public $records = array(
+		array(
+			'id' => '1',
+			'user_attribute_key' => 'email',
+			'data_type_key' => 'email',
+			'row' => '1',
+			'col' => '1',
+			'weight' => '1',
+			'required' => true,
+			'display' => true,
+			'only_administrator_readable' => false,
+			'only_administrator_editable' => false,
+			'is_system' => false,
+			'display_label' => true,
+			'display_search_result' => true,
+			'self_public_setting' => true,
+			'self_email_setting' => false,
+			'is_multilingualization' => true,
+		),
+		[
+			'user_attribute_key' => 'moblie_mail',
+			'data_type_key' => 'email'
+		],
+		[
+			'user_attribute_key' => 'other_mail',
+			'data_type_key' => 'email'
+		],
+		//array(
+		//	'id' => '2',
+		//	'user_attribute_key' => 'radio_attribute_key',
+		//	'data_type_key' => 'radio',
+		//	'row' => '1',
+		//	'col' => '1',
+		//	'weight' => '2',
+		//	'required' => true,
+		//	'display' => true,
+		//	'only_administrator_readable' => false,
+		//	'only_administrator_editable' => true,
+		//	'is_system' => false,
+		//	'display_label' => true,
+		//	'display_search_result' => true,
+		//	'self_public_setting' => true,
+		//	'self_email_setting' => false,
+		//	'is_multilingualization' => true,
+		//),
+		//array(
+		//	'id' => '3',
+		//	'user_attribute_key' => 'system_attribute_key',
+		//	'data_type_key' => 'text',
+		//	'row' => '1',
+		//	'col' => '1',
+		//	'weight' => '3',
+		//	'required' => true,
+		//	'display' => false,
+		//	'only_administrator_readable' => true,
+		//	'only_administrator_editable' => true,
+		//	'is_system' => true,
+		//	'display_label' => true,
+		//	'display_search_result' => true,
+		//	'self_public_setting' => true,
+		//	'self_email_setting' => false,
+		//	'is_multilingualization' => true,
+		//),
+	);
+
+}

--- a/Test/Fixture/UserAttributeSettingForMailFixture.php
+++ b/Test/Fixture/UserAttributeSettingForMailFixture.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * UserAttributeSettingFixture
+ *
+ * @author Noriko Arai <arai@nii.ac.jp>
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ * @copyright Copyright 2014, NetCommons Project
+ */
+
+App::uses('UserAttributeSettingFixture', 'UserAttributes.Test/Fixture');
+
+/**
+ * UserAttributeSettingFixture
+ *
+ * @author Shohei Nakajima <nakajimashouhei@gmail.com>
+ * @package NetCommons\UserAttributes\Test\Fixture
+ * @codeCoverageIgnore
+ */
+class UserAttributeSettingForMailFixture extends UserAttributeSettingFixture {
+
+/**
+ * Model name
+ *
+ * @var string
+ */
+	public $name = 'UserAttributeSetting';
+
+/**
+ * Full Table Name
+ *
+ * @var string
+ */
+	public $table = 'user_attribute_settings';
+
+/**
+ * Records
+ *
+ * @var array
+ */
+	public $records = array(
+		[
+			'id' => '1',
+			'user_attribute_key' => 'email',
+			'data_type_key' => 'email',
+			'row' => '1',
+			'col' => '1',
+			'weight' => '1',
+			'required' => true,
+			'display' => true,
+			'only_administrator_readable' => false,
+			'only_administrator_editable' => false,
+			'is_system' => false,
+			'display_label' => true,
+			'display_search_result' => true,
+			'self_public_setting' => true,
+			'self_email_setting' => false,
+			'is_multilingualization' => true,
+		],
+		[
+			'user_attribute_key' => 'moblie_mail',
+			'data_type_key' => 'email'
+		],
+	);
+
+}


### PR DESCRIPTION
user_attribute_settingsテーブルを参照するように変更しました。
これで会員項目設定でeメールタイプを追加したときにそちらにも通知メールが送られるようになります。